### PR TITLE
Complete an argument rename and silence byte-compiler

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1238,7 +1238,8 @@ Call `bash-completion-dynamic' or `bash-completion-nocomint'."
           result)))
 (make-obsolete
  'bash-completion-dynamic-complete-0
- "call bash-completion-dynamic or bash-completion-dynamic-nocomint")
+ "call bash-completion-dynamic or bash-completion-dynamic-nocomint"
+ "2.1")
 
 (defun bash-completion-dynamic-try-wordbreak-complete (stub stub-start pos open-quote)
   "Obsolete function, kept for backward compatibility.
@@ -1252,7 +1253,8 @@ be called from outside bash-completion.
     (cons (buffer-substring-no-properties (car result) pos) result)))
 (make-obsolete
  'bash-completion-dynamic-try-wordbreak-complete
- 'bash-completion--try-wordbreak-complete)
+ 'bash-completion--try-wordbreak-complete
+ "2.1")
 
 (provide 'bash-completion)
 ;;; bash-completion.el ends here

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -373,7 +373,7 @@ passed to the parameter OPEN-QUOTE.
 
 This function is not meant to be called outside of
 `bash-completion-dynamic-complete'."
-  (let* ((wordbreak-split (bash-completion-last-wordbreak-split stub))
+  (let* ((wordbreak-split (bash-completion-last-wordbreak-split parsed-stub))
          (before-wordbreak (nth 0 wordbreak-split))
 	 (after-wordbreak (nth 1 wordbreak-split))
          (separator (nth 2 wordbreak-split))


### PR DESCRIPTION
Please consider giving my [`auto-compile`](https://github.com/emacscollective/auto-compile) package a try. It makes it much less likely that such mistakes go unnoticed.