### PR TITLE
Add a new option to disable the use of separate processes to perform completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,17 @@ running in term mode.  Also, term mode is not available in
 shell-command prompts.
 
 Bash completion can also be run programatically, outside of a
-shell-mode command, by calling
-`bash-completion-dynamic-complete-nocomint'
+shell-mode command, by setting
+`bash-completion-use-separate-processes` to a non-nil value (which is
+the default) and by calling
+`bash-completion-dynamic-complete-nocomint`.
 
 ## INSTALLATION
 
 1. copy bash-completion.el into a directory that's on Emacs load-path
 2. add this into your .emacs file:
 
-        (autoload 'bash-completion-dynamic-complete 
+        (autoload 'bash-completion-dynamic-complete
           "bash-completion"
           "BASH completion hook")
         (add-hook 'shell-dynamic-complete-functions
@@ -56,6 +58,9 @@ and then adding this to your .bashrc:
 
     . /etc/bash_completion
 
+NOTE: The following paragraph are not relevant when
+`bash-completion-use-separate-processes` is nil.
+
 Right after enabling programmable bash completion, and whenever you
 make changes to you .bashrc, call `bash-completion-reset' to make
 sure bash completion takes your new settings into account.
@@ -77,6 +82,9 @@ started from it. Processes started by bash-completion.el have
 the environment variable EMACS_BASH_COMPLETE set to t.
 
 ## CAVEATS
+
+NOTE: This section is not relevant when
+`bash-completion-use-separate-processes` is nil.
 
 Using a separate process for doing the completion has several
 important disadvantages:

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -400,7 +400,8 @@ returned."
                  (with-current-buffer (bash-completion--get-buffer process)
                    (buffer-substring-no-properties
                     (point-min) (point-max))))
-    (process-put process 'bash-major-version bash-major-version)))
+    (process-put process 'bash-major-version bash-major-version)
+    (process-put process 'setup-done t)))
 
 ;;; ---------- Inline functions
 
@@ -1136,7 +1137,7 @@ is set to t."
   "Setup the process associated with the current buffer and return it."
   (when (derived-mode-p 'comint-mode)
     (let ((process (get-buffer-process (current-buffer))))
-      (unless (or (not process) (process-get process 'complete-p))
+      (unless (or (not process) (process-get process 'setup-done))
         (bash-completion--setup-bash-common process))
       process)))
 

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1355,14 +1355,18 @@ Return the status code of the command, as a number."
         (comint-preoutput-filter-functions
          (if bash-completion-use-separate-processes
              comint-preoutput-filter-functions
-           '(bash-completion--output-filter))))
+           '(bash-completion--output-filter)))
+        (send-string (if bash-completion-use-separate-processes
+                         #'process-send-string
+                       #'comint-send-string)))
     (with-current-buffer (bash-completion--get-buffer process)
       (erase-buffer)
-      (comint-send-string process (concat
-                                   commandline
-                                   (when (not bash-completion-use-separate-processes)
-                                     "; echo -e \"\v$?\"; history -d -1")
-                                   "\n"))
+      (funcall send-string process
+               (concat
+                commandline
+                (when (not bash-completion-use-separate-processes)
+                  "; echo -e \"\v$?\"; history -d -1")
+                "\n"))
       (unless (bash-completion--wait-for-prompt process prompt-regexp timeout)
         (error (concat
                 "Timeout while waiting for an answer from "

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1364,7 +1364,10 @@ and would like bash completion in Emacs to take these changes into account."
         (comint-preoutput-filter-functions '(bash-completion--output-filter)))
     (with-current-buffer (bash-completion--get-buffer process)
       (erase-buffer)
-      (comint-send-string process (concat commandline "; echo -e \"\v$?\"" "\n"))
+      (comint-send-string process (concat
+                                   commandline
+                                   "; echo -e \"\v$?\""
+                                   "; history -d -1\n"))
       (unless (bash-completion--wait-for-output process prompt-regex timeout)
         (error (concat
                 "Timeout while waiting for an answer from "

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1329,7 +1329,7 @@ and would like bash completion in Emacs to take these changes into account."
   (let ((no-timeout t))
     (while (and no-timeout
                 (not (re-search-backward prompt-regexp nil t)))
-      (setq no-timeout (accept-process-output process timeout)))
+      (setq no-timeout (accept-process-output process timeout nil t)))
     no-timeout))
 
 (defun bash-completion--get-prompt-regexp ()

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -486,7 +486,7 @@ When doing completion outside of a comint buffer, call
     (error (if (not bash-completion-use-separate-processes)
                ;; try again with a separate process
                (let* ((bash-completion-use-separate-processes t)
-                      (process (bash-completion-require-process)))
+                      (process (bash-completion-get-process)))
                  (bash-completion-comm comp process))
              ;; re-throw the error
              (signal (car err) (cdr err))))))
@@ -512,12 +512,12 @@ Returns (list stub-start stub-end completions) with
   (when bash-completion-enabled
     (let ((bash-completion-use-separate-processes
            bash-completion-use-separate-processes)
-          (process (bash-completion-require-process)))
+          (process (bash-completion-get-process)))
       (when (and (not process) (not bash-completion-use-separate-processes))
         ;; no process associated with the current buffer, create a
         ;; separate completion process
         (setq bash-completion-use-separate-processes t)
-        (setq process (bash-completion-require-process)))
+        (setq process (bash-completion-get-process)))
       (let* ((comp (bash-completion--parse
                     comp-start comp-pos
                     (process-get process 'wordbreaks)
@@ -1038,7 +1038,7 @@ Return a CONS containing (before . after)."
 
 ;;; ---------- Functions: bash subprocess
 
-(defun bash-completion--require-separate-process ()
+(defun bash-completion--get-or-create-separate-process ()
   "Return the bash completion process or start it.
 
 If a bash completion process is already running, return it.
@@ -1133,7 +1133,7 @@ is set to t."
                   (bash-completion-kill process)
                 (error nil)))))))))
 
-(defun bash-completion--require-same-process ()
+(defun bash-completion--get-same-process ()
   "Setup the process associated with the current buffer and return it."
   (when (derived-mode-p 'comint-mode)
     (let ((process (get-buffer-process (current-buffer))))
@@ -1141,16 +1141,16 @@ is set to t."
         (bash-completion--setup-bash-common process))
       process)))
 
-(defun bash-completion-require-process ()
+(defun bash-completion-get-process ()
   "Setup and return a bash completion process.
 
 If `bash-completion-use-separate-processes' is non-nil,
-`bash-completion--require-separate-process' is called to get the
-process, otherwise `bash-completion--require-same-process' is
+`bash-completion--get-or-create-separate-process' is called to
+get the process, otherwise `bash-completion--get-same-process' is
 used. "
   (if bash-completion-use-separate-processes
-      (bash-completion--require-separate-process)
-    (bash-completion--require-same-process)))
+      (bash-completion--get-or-create-separate-process)
+    (bash-completion--get-same-process)))
 
 (defun bash-completion-cd-command-prefix ()
   "Build a command-line that CD to default-directory.
@@ -1305,7 +1305,7 @@ and would like bash completion in Emacs to take these changes into account."
 
 (defun bash-completion-buffer ()
   "Return the buffer of the BASH process, create the BASH process if necessary."
-  (bash-completion--get-buffer (bash-completion-require-process)))
+  (bash-completion--get-buffer (bash-completion-get-process)))
 
 (defun bash-completion-is-running ()
   "Check whether the bash completion process is running."
@@ -1345,7 +1345,7 @@ and would like bash completion in Emacs to take these changes into account."
 COMMANDLINE should be a bash command, without the final newline.
 
 PROCESS should be the bash process, if nil this function calls
-`bash-completion-require-process' which might start a new process
+`bash-completion-get-process' which might start a new process
 depending on the value of
 `bash-completion-use-separate-processes'.
 
@@ -1358,7 +1358,7 @@ result of the command in the bash completion process buffer or in
 `bash-completion-use-separate-processes' is nil.
 
 Return the status code of the command, as a number."
-  (let ((process (or process (bash-completion-require-process)))
+  (let ((process (or process (bash-completion-get-process)))
         (timeout (or timeout bash-completion-process-timeout))
         (prompt-regexp (if bash-completion-use-separate-processes
                            "\t-?[[:digit:]]+\v"

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1139,10 +1139,11 @@ is set to t."
 
 (defun bash-completion--require-same-process ()
   "Setup the process associated with the current buffer and return it."
-  (let ((process (get-buffer-process (current-buffer))))
-    (unless (or (not process) (process-get process 'complete-p))
-      (bash-completion--setup-bash-common process))
-    process))
+  (when (derived-mode-p 'comint-mode)
+    (let ((process (get-buffer-process (current-buffer))))
+      (unless (or (not process) (process-get process 'complete-p))
+        (bash-completion--setup-bash-common process))
+      process)))
 
 (defun bash-completion-require-process ()
   "Setup and return a bash completion process.

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1376,7 +1376,10 @@ Return the status code of the command, as a number."
         (search-backward "\v"))
       (let ((status-code (string-to-number
                           (buffer-substring-no-properties
-                           (1+ (point)) (line-end-position)))))
+                           (1+ (point))
+                           (if bash-completion-use-separate-processes
+                               (1- (line-end-position))
+                             (line-end-position))))))
         (delete-region (point) (point-max))
         (if (string=
              "124"

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -146,7 +146,12 @@ BASH completion is only available in the environment for which
   :group 'bash-completion)
 
 (defcustom bash-completion-use-separate-processes t
-  "Enable/disable the use of separate processes to do the completion."
+  "Enable/disable the use of separate processes to perform completion.
+
+When set to a non-nil value, separate processes will be used to
+perform completion. If nil, the process associated with the
+current buffer is used to perform completion. If no process is
+associated with the current buffer, a separate process is used."
   :type 'boolean
   :group 'bash-completion)
 
@@ -158,8 +163,10 @@ the name of the bash command if it is on Emacs' PATH. This should
 point to a recent version of BASH, 3 or 4, with support for
 command-line completion.
 
-This variable is not used if
-`bash-completion-use-separate-processes' is nil."
+This variable is only used when creating separate processes for
+performing completion. See
+`bash-completion-use-separate-processes' for further
+explanation."
   :type '(file :must-match t)
   :group 'bash-completion)
 
@@ -170,16 +177,20 @@ This is the path of an BASH executable available on the remote machine.
 Best is to just specify \"bash\" and rely on the PATH being set correctly
 for the remote connection.
 
-This variable is not used if
-`bash-completion-use-separate-processes' is nil."
+This variable is only used when creating separate processes for
+performing completion. See
+`bash-completion-use-separate-processes' for further
+explanation."
   :type '(string)
   :group 'bash-completion)
 
 (defcustom bash-completion-args '("--noediting")
   "Args passed to the BASH shell.
 
-This variable is not used if
-`bash-completion-use-separate-processes' is nil."
+This variable is only used when creating separate processes for
+performing completion. See
+`bash-completion-use-separate-processes' for further
+explanation."
   :type '(repeat (string :tag "Argument"))
   :group 'bash-completion)
 
@@ -209,8 +220,10 @@ Only relevant when using bash completion in a shell, through
 The first thing bash is supposed to do is process /etc/bash_complete,
 which typically takes a long time.
 
-This variable is not used if
-`bash-completion-use-separate-processes' is nil."
+This variable is only used when creating separate processes for
+performing completion. See
+`bash-completion-use-separate-processes' for further
+explanation."
   :type '(float)
   :group 'bash-completion)
 
@@ -231,8 +244,10 @@ to remove the extra space bash adds after a completion."
   '("~/.emacs_bash.sh" "~/.emacs.d/init_bash.sh")
   "Shell files that, if they exist, will be sourced at the beginning of a bash completion subprocess.
 
-This variable is not used if
-`bash-completion-use-separate-processes' is nil.")
+This variable is only used when creating separate processes for
+performing completion. See
+`bash-completion-use-separate-processes' for further
+explanation.")
 
 (defvar bash-completion-wordbreaks ""
   "Extra wordbreaks to use when tokenizing, in `bash-completion-tokenize'.")
@@ -249,10 +264,7 @@ This variable is not used when
   "Bash processes alist.
 
 Mapping between remote paths as returned by `file-remote-p' and
-Bash processes.
-
-This variable is not used if
-`bash-completion-use-separate-processes' is nil.")
+Bash processes.")
 
 (defconst bash-completion-special-chars "[^-0-9a-zA-Z_./\n=]"
   "Regexp of characters that must be escaped or quoted.")

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1365,7 +1365,7 @@ Return the status code of the command, as a number."
                (concat
                 commandline
                 (when (not bash-completion-use-separate-processes)
-                  "; echo -e \"\v$?\"; history -d -1")
+                  "; echo -e \"\v$?\"; history -d $((HISTCMD - 1))")
                 "\n"))
       (unless (bash-completion--wait-for-prompt process prompt-regexp timeout)
         (error (concat

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1328,6 +1328,13 @@ and would like bash completion in Emacs to take these changes into account."
       (setq no-timeout (accept-process-output process timeout)))
     no-timeout))
 
+(defun bash-completion--get-prompt-regexp ()
+  (if comint-use-prompt-regexp
+      comint-prompt-regexp
+    (let* ((end (comint-line-beginning-position))
+           (start (previous-property-change end)))
+      (regexp-quote (buffer-substring-no-properties start end)))))
+
 (defun bash-completion-send (commandline &optional process timeout)
   "Send a command to the bash completion process.
 
@@ -1351,7 +1358,7 @@ Return the status code of the command, as a number."
         (timeout (or timeout bash-completion-process-timeout))
         (prompt-regexp (if bash-completion-use-separate-processes
                            "\t-?[[:digit:]]+\v"
-                         comint-prompt-regexp))
+                         (bash-completion--get-prompt-regexp)))
         (comint-preoutput-filter-functions
          (if bash-completion-use-separate-processes
              comint-preoutput-filter-functions

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1321,10 +1321,10 @@ and would like bash completion in Emacs to take these changes into account."
       (setq bash-completion-processes (delq entry bash-completion-processes)))
     running))
 
-(defun bash-completion--wait-for-prompt (process output-regexp timeout)
+(defun bash-completion--wait-for-prompt (process prompt-regexp timeout)
   (let ((no-timeout t))
     (while (and no-timeout
-                (not (re-search-backward output-regexp nil t)))
+                (not (re-search-backward prompt-regexp nil t)))
       (setq no-timeout (accept-process-output process timeout)))
     no-timeout))
 

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1371,7 +1371,7 @@ Return the status code of the command, as a number."
       (funcall send-string process
                (concat
                 commandline
-                (when (not bash-completion-use-separate-processes)
+                (unless bash-completion-use-separate-processes
                   "; echo -e \"\v$?\"; history -d $((HISTCMD - 1))")
                 "\n"))
       (unless (bash-completion--wait-for-prompt process prompt-regexp timeout)
@@ -1379,7 +1379,7 @@ Return the status code of the command, as a number."
                 "Timeout while waiting for an answer from "
                 "bash-completion process.\nProcess output: <<<EOF\n%sEOF")
                (buffer-string)))
-      (when (not bash-completion-use-separate-processes)
+      (unless bash-completion-use-separate-processes
         (search-backward "\v"))
       (let ((status-code (string-to-number
                           (buffer-substring-no-properties

--- a/test/bash-completion-integration-test.el
+++ b/test/bash-completion-integration-test.el
@@ -68,7 +68,7 @@
 	    ;; do a completion and return the result
 	    (with-current-buffer shell-buffer
               (let ((comint-dynamic-complete-functions '(bash-completion-dynamic-complete))
-                    (bash-major-version (process-get (bash-completion-require-process)
+                    (bash-major-version (process-get (bash-completion-get-process)
                                                      'bash-major-version)))
                 (progn ,@body))))
         (progn ;; finally

--- a/test/bash-completion-test.el
+++ b/test/bash-completion-test.el
@@ -946,7 +946,7 @@ before calling `bash-completion-dynamic-complete-nocomint'.
          (setq --process-buffer (current-buffer))
          (with-temp-buffer
            (setq --test-buffer (current-buffer))
-           (cl-letf (((symbol-function 'bash-completion-require-process) (lambda () 'process))
+           (cl-letf (((symbol-function 'bash-completion-get-process) (lambda () 'process))
                      ((symbol-function 'process-put)
                       (lambda (process prop value)
                         (cond ((and (eq 'process process) (eq 'complete-p prop))


### PR DESCRIPTION
The drawback of using separate processes to do the completion is that
the completion process is not aware of any changes made to bash in the
current buffer. Setting the new option
`bash-completion-use-separate-processes' to nil, remove this
limitation by using the bash associated with the current buffer to
perform the completion.