### PR TITLE
bash-completion.el (bash-completion-quote): Add case for empty string

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -254,7 +254,7 @@ Bash processes")
   open-quote     ; quote open at stub end: nil, ?' or ?\""
   compgen-args   ; compgen arguments for this command (list of strings)
   wordbreaks     ; value of COMP_WORDBREAKS active for this completion
-  compopt        ; options forced with compopt nil or `(nospace . ,bool) 
+  compopt        ; options forced with compopt nil or `(nospace . ,bool)
 )
 
 (defun bash-completion--type (comp)
@@ -431,11 +431,15 @@ Return one string containing WORDS."
 
 If WORD contains characters that aren't known to be harmless, this
 functions adds single quotes around it and return the result."
-  (if (string-match "^[a-zA-Z0-9_./-]*$" word)
-      word
-    (concat "'"
-	    (replace-regexp-in-string "'" "'\\''" word nil t)
-	    "'")))
+  (cond
+    ((string= "" word)
+     "''")
+    ((string-match "^[a-zA-Z0-9_./-]*$" word)
+     word)
+    (t
+     (concat "'"
+             (replace-regexp-in-string "'" "'\\''" word nil t)
+             "'"))))
 
 (defun bash-completion--parse (comp-start comp-pos wordbreaks bash-major-version)
   "Process a command line split into TOKENS that end at POS.
@@ -1081,7 +1085,7 @@ The returned alist is a sligthly parsed version of the output of
                          (line-end-position)))))
             (when (string= "complete" (car words))
               (if (member "-D" (cdr words))
-                  ;; default completion 
+                  ;; default completion
                   (push (cons nil (delete "-D" (cdr words))) alist)
                 ;; normal completion
                 (let* ((reverse-wordsrest (nreverse (cdr words)))


### PR DESCRIPTION
I was just noticed I didn't PR this commit from some time ago. Here's how it changes the behavior:

```elisp
;; Before:
(bash-completion-quote "")
;; => ""

;; After
(bash-completion-quote "")
;; => "''"
```

If I remember correctly, the intention is to fix the difference between bash completion and emacs-bash-completion.el. When <kbd>TAB</kbd> is issued with the last word being empty, bash completion passes that last empty string in the list, which emacs-bash-completion.el just has a shorter list with no empty string.
