### PR TITLE
Fix typo

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -402,7 +402,7 @@ Returns (list stub-start stub-end completions) with
          (bash-completion-comm comp process))))))
 
 (defun bash-completion--find-last (elt array)
-  "Return the position of the last intance of ELT in array or nil."
+  "Return the position of the last instance of ELT in array or nil."
   (catch 'bash-completion-return
     (let ((array-len (length array)))
       (dotimes (index array-len)


### PR DESCRIPTION
Unfortunately I missed that before.  Because `codespell` did not auto-correct because it wanted me to chose from two possible corrections.