### PR TITLE
Making sure that line editing is turned off

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -987,7 +987,11 @@ is set to t."
                 ;; but only in some environment. disable this dreadful
                 ;; business to get a saner way of handling spaces.
                 ;; Noticed in bash_completion v1.872.
-                "function quote_readline { echo \"$1\"; }\n"))
+                "function quote_readline { echo \"$1\"; }\n"
+                ;; User's profiles can turn line editing back on,
+                ;; so make sure it's off
+                "set +o emacs\n"
+                "set +o vi\n"))
 
               (bash-completion-send "PROMPT_COMMAND='';PS1='\t$?\v'" process bash-completion-initial-timeout)
               (bash-completion-send "complete -p" process)


### PR DESCRIPTION
If either `set -o emacs` or `set -o vi` is in the user's `.bashrc` the completion process fails to start. That is expected (this is why bash is run with `--noediting`). This change takes into account that a user might have explicitly turned it on in their configuration.