### PR TITLE
Always ensure that a copy of the candidate list is returned

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1702,13 +1702,6 @@ using the current Emacs completion style."
                                               (bash-completion--unparsed-stub comp)) "" str)))
             (cond
              ((null action) (try-completion completion-string result predicate))
-             ((and (eq action t) (equal "" completion-string) predicate)
-              (delq nil (mapcar
-                         (lambda (elt)
-                           (when (funcall predicate elt) elt))
-                         result)))
-             ((and (eq action t) (equal "" completion-string))
-              result)
              ((eq action t)
               (all-completions completion-string result predicate))
              (t (test-completion str result predicate)))))))))


### PR DESCRIPTION
The caller of the completion table is allowed to mutate the list in place. See https://github.com/minad/corfu/issues/31 for the original issue.