### PR TITLE
Replace `cl` with `cl-lib`

### DIFF
--- a/test/bash-completion-test.el
+++ b/test/bash-completion-test.el
@@ -30,7 +30,7 @@
 
 ;;; Code:
 (require 'bash-completion)
-(require 'cl)
+(require 'cl-lib)
 (require 'ert)
 
 ; for Emacs 24.1


### PR DESCRIPTION
Package `cl` has been deprecated in Emacs 27