### PR TITLE
improve path completion to show only the last path segment

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -544,11 +544,14 @@ Returns (list stub-start stub-end completions) with
                     comp-start comp-pos
                     (process-get process 'wordbreaks)
                     (process-get process 'bash-major-version)))
-             (stub-start (bash-completion--stub-start comp)))
-
+             (stub-start (bash-completion--stub-start comp))
+             (stub (bash-completion--stub comp)))
         (bash-completion--customize comp process)
         (list
-         stub-start
+         (let ((last-separator (string-match "/[^/]*$" stub)))
+           (if last-separator
+               (- comp-pos (- (length stub) last-separator 1))
+             stub-start))
          comp-pos
          (if dynamic-table
              (bash-completion--completion-table-with-cache
@@ -1006,7 +1009,11 @@ for directory name detection to work."
        (t (setq suffix close-quote-str))))
 
     ;; put everything back together
-    (concat unparsed-prefix
+    (concat (let ((last-separator (string-match "/[^/]*$" unparsed-prefix)))
+              (if last-separator
+                  (substring unparsed-prefix (1+ last-separator)
+                             (length unparsed-prefix))
+                unparsed-prefix))
             (bash-completion-escape-candidate rest open-quote)
             suffix)))
 


### PR DESCRIPTION
Hi,

This is a simple PR to refine the output of path completion by removing the prefix.

For example, here is the screenshot of the current path completion feature: the prefix `~/workspace/rust` is duplicated in all completion candidates:

![bash-completion-1](https://user-images.githubusercontent.com/193967/197148330-386b75b6-bcb2-4649-bdb0-61b00bbb6ebc.png)

And here is the output after applying my PR, 

![bash-completion-2](https://user-images.githubusercontent.com/193967/197148357-243c73fd-4082-4248-99d8-9861204a689f.png)

Can you review the PR and consider merging it?

Thanks!
