### PR TITLE
Use default completion spec when no comp spec is found for current cmd

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -1257,7 +1257,7 @@ The returned alist is a slightly parsed version of the output of
   (unless (eq 'command (bash-completion--type comp))
     (let* ((complete-p (concat "complete -p "
                                (bash-completion-quote (bash-completion--command comp))
-                               " 2>/dev/null || complete -p "))
+                               " 2>/dev/null || complete -p -D"))
            (status (bash-completion-send
                     (concat complete-p "&& type -t __emacs_complete_wrapper >/dev/null 2>&1"))))
     (setf (bash-completion--compgen-args comp)


### PR DESCRIPTION
The commit 718d768 introduced a regression when the current command has no completion spec defined. Instead of using the default completion spec, it uses the first one returned by "complete -p". This commit restores the old behaviour.