### PR TITLE
Remove useless require call

### DIFF
--- a/bash-completion.el
+++ b/bash-completion.el
@@ -113,7 +113,6 @@
 (require 'comint)
 (require 'cl-lib)
 (require 'shell)
-(require 'rx)
 
 ;;; Customization
 (defgroup bash-completion nil


### PR DESCRIPTION
In my pull request #60 I forgot to remove a useless call to load the `rx` feature. Sorry :)