### PR TITLE
Add eshell setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,41 +64,38 @@ from normal shell processes.
 
 ### Completion at point
 
-Additionally, you can enable bash completion in any buffer that contains bash 
-commands. To do that, call 
+You can also use bash completion as an additional completion function
+in any buffer that contains bash commands. To do that, add
+`bash-completion-capf-nonexclusive` to the buffer-local
+`completion-at-point-functions`. For example, you can setup bash
+completion in `eshell-mode` by invoking
+
+```elisp
+(add-hook 'eshell-mode-hook
+          (lambda ()
+            (add-hook 'completion-at-point-functions
+                      'bash-completion-capf-nonexclusive nil t)))
+```
+
+There is also a lower-level function
+`bash-completion-dynamic-complete-nocomint` which allows you to
+construct your own `completion-at-point` function.
+
 ```elisp
 (bash-completion-dynamic-complete-nocomint COMP-START COMP-POS DYNAMIC-TABLE)
-``` 
-from a function added to `completion-at-point-functions`. 
+```
 
-The trickiest part is setting COMP-START to where the bash command starts;
-It depends on the mode of the calling buffer and might, in some cases, span 
-multiple lines.
+COMP-START is where the bash command starts --- it depends on the mode
+of the calling buffer. In most cases, `line-beginning-position` works
+because it uses `field` boundaries.
 
 COMP-POS is usually the current position of the cursor.
 
-When calling from `completion-at-point`, make sure to pass a non-nil value 
-to the DYNAMIC-TABLE argument so it returns a function instead of a list
-of strings. This isn't just an optimization: returning a function instead 
-of a list tells Emacs it should avoids post-filtering the results and 
-possibly discarding useful completion from bash.
-
-For example, here's a function to to do bash completion from an 
-eshell buffer. To try it out, add the function below to your init file
-and bind `bash-completion-from-eshell` to a custom shortcut.
-
-```elisp
-(defun bash-completion-from-eshell ()
-  (interactive)
-  (let ((completion-at-point-functions
-         '(bash-completion-eshell-capf)))
-    (completion-at-point)))
-
-(defun bash-completion-eshell-capf ()
-  (bash-completion-dynamic-complete-nocomint
-   (save-excursion (eshell-bol) (point))
-   (point) t))
-```
+When calling from `completion-at-point`, make sure to pass a non-nil
+value to the DYNAMIC-TABLE argument so it returns a function instead
+of a list of strings. This isn't just an optimization: returning a
+function instead of a list tells Emacs it should avoids post-filtering
+the results and possibly discarding useful completion from bash.
 
 ## TROUBLESHOOTING
 

--- a/bash-completion.el
+++ b/bash-completion.el
@@ -33,6 +33,17 @@
 ;;
 ;; to your initialisation file.
 ;;
+;; You can also use bash completion as an additional completion
+;; function in any buffer that contains bash commands. To do that, add
+;; `bash-completion-capf-nonexclusive' to the buffer-local
+;; `completion-at-point-functions'. For example, you can setup bash
+;; completion in `eshell-mode' by invoking
+;;
+;; (add-hook 'eshell-mode-hook
+;;           (lambda ()
+;;             (add-hook 'completion-at-point-functions
+;;                       'bash-completion-capf-nonexclusive nil t)))
+;;
 ;; The completion will be aware of bash builtins, alii and functions.
 ;; It does file expansion does file expansion inside of
 ;; colon-separated variables and after redirections (> or <), and
@@ -523,6 +534,20 @@ When doing completion outside of a comint buffer, call
       ;; cleanup
       (if message-timer
           (cancel-timer message-timer)))))
+
+;;;###autoload
+(defun bash-completion-capf-nonexclusive ()
+  "Bash completion function for `completion-at-point-functions'.
+
+Returns the same list as the one returned by
+`bash-completion-dynamic-complete-nocomint' appended with
+\(:exclusive no) so that other completion functions are tried
+when bash-completion fails to match the text at point."
+  (let ((compl (bash-completion-dynamic-complete-nocomint
+                (line-beginning-position)
+                (point) t)))
+    (when compl
+      (append compl '(:exclusive no)))))
 
 ;;;###autoload
 (defun bash-completion-dynamic-complete-nocomint


### PR DESCRIPTION
### Motivation

The built-in completion function of `eshell`, `pcomplete`, works well with elisp functions but does not cover all the shell commands. bash-completion needs to be added as an **additional** completion method in `eshell`.

### Changes

- `bash-completion-setup-eshell` registers bash completion for eshell buffers and command prompt.
- `bash-completion-dynamic-complete-eshell` returns the same list as the one returned by `bash-completion-dynamic-complete-nocomint` appended with `(:exclusive no)` so that `pcomplete` is tried when bash-completion fails to match the text at point.
- Related documentation.

### Related issues

This fixes #24 in a convenient way. Users do not need to bind a different key for bash-completion to work in `eshell`. It adds a completion function to `completion-at-point-functions` for eshells buffers and prompts.